### PR TITLE
fix path to git in package.json, fix regex ignore example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var classPrfx = require('postcss-class-prefix');
 
 var css = fs.readFileSync('css/my-file.css', 'utf8').toString();
 var out = postcss()
-          .use(classPrfx('my-prefix-', { ignore: [/\.ng-/, 'some-class-to-ignore']}))
+          .use(classPrfx('my-prefix-', { ignore: [/ng-/, 'some-class-to-ignore']}))
           .process(css);
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/thompsongl/postcss-class-prefixer.git"
+    "url": "git://github.com/thompsongl/postcss-class-prefix.git"
   },
   "keywords": [
     "css",


### PR DESCRIPTION
the regex doesn't need the `.` as the check is against the classname, not the selector.
