### PR TITLE
update dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function classPrefix(prefix, options) {
 
   return function(root) {
 
-    root.eachRule(function (rule) {
+    root.walkRules(function (rule) {
       if (!rule.selectors){
         return rule;
       }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "files": [
     "index.js"
   ],
+  "dependencies": {
+    "postcss": "^5.0.4"
+  },
   "devDependencies": {
-    "mocha": "^2.0.0",
-    "postcss": "^4.1.0"
+    "mocha": "^2.0.0"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
1. Move 'postcss' from devDependencies to dependencies.
   When using grunt-postcss, the 'postcss' module can not be found in the index.js file, because after installing 'postcss-class-prefix', the 'postcss' module has not be downloaded automatically
2. In version 5.0.4,  eachRule is deprecate, and should be replaced with walkRules.
