### PR TITLE
Extended the prefixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ __Example input__
 .Component { /* ... */ }
 .Component--modifier { /* ... */ }
 .Component-descendent { /* ... */ }
+tag .Component-descendent { /* ... */ }
 ```
 
 __Example output__
@@ -18,6 +19,7 @@ __Example output__
 .pfx-Component { /* ... */ }
 .pfx-Component--modifier { /* ... */ }
 .pfx-Component-descendent { /* ... */ }
+tag .pfx-Component-descendent { /* ... */ }
 ```
 
 

--- a/test/fixtures/ignore.css
+++ b/test/fixtures/ignore.css
@@ -21,3 +21,39 @@
 .no-fontface .Component {
   font-size: 12px;
 }
+
+element.no-flexbox {
+    color: white;
+}
+
+element .no-flexbox {
+    color: white;
+}
+
+.no-flexbox element .Component {
+    color: white;
+}
+
+.no-flexbox element.Component {
+    color: white;
+}
+
+.no-flexbox.Component {
+    color: white;
+}
+
+.no-flexbox:not(.Component) {
+    color: white;
+}
+
+.no-flexbox>.Component {
+    color: white;
+}
+
+*[class^="no-flexbox"] {
+    color: white;
+}
+
+*[class^="no-flexbox"] *[class^="no-flexbox"] *[class^="Component"] {
+    color: white;
+}

--- a/test/fixtures/ignore.expected.css
+++ b/test/fixtures/ignore.expected.css
@@ -21,3 +21,39 @@
 .no-fontface .prfx-Component {
   font-size: 12px;
 }
+
+element.no-flexbox {
+    color: white;
+}
+
+element .no-flexbox {
+    color: white;
+}
+
+.no-flexbox element .prfx-Component {
+    color: white;
+}
+
+.no-flexbox element.prfx-Component {
+    color: white;
+}
+
+.no-flexbox.prfx-Component {
+    color: white;
+}
+
+.no-flexbox:not(.prfx-Component) {
+    color: white;
+}
+
+.no-flexbox>.prfx-Component {
+    color: white;
+}
+
+*[class^="no-flexbox"] {
+    color: white;
+}
+
+*[class^="no-flexbox"] *[class^="no-flexbox"] *[class^="prfx-Component"] {
+    color: white;
+}

--- a/test/fixtures/source.css
+++ b/test/fixtures/source.css
@@ -5,3 +5,39 @@
 .my-class .with-another-class {
   box-sizing: border-box;
 }
+
+element.class {
+    color: white;
+}
+
+element .class {
+    color: white;
+}
+
+.class element .otherclass {
+    color: white;
+}
+
+.class element.otherclass {
+    color: white;
+}
+
+.class.otherclass {
+    color: white;
+}
+
+.class:not(.otherclass) {
+    color: white;
+}
+
+.class>.otherclass {
+    color: white;
+}
+
+*[class^="col-"] {
+    color: white;
+}
+
+*[class^="col-"] *[class^="col-"] *[class^="col2-"] {
+    color: white;
+}

--- a/test/fixtures/source.expected.css
+++ b/test/fixtures/source.expected.css
@@ -5,3 +5,39 @@
 .prfx-my-class .prfx-with-another-class {
   box-sizing: border-box;
 }
+
+element.prfx-class {
+    color: white;
+}
+
+element .prfx-class {
+    color: white;
+}
+
+.prfx-class element .prfx-otherclass {
+    color: white;
+}
+
+.prfx-class element.prfx-otherclass {
+    color: white;
+}
+
+.prfx-class.prfx-otherclass {
+    color: white;
+}
+
+.prfx-class:not(.prfx-otherclass) {
+    color: white;
+}
+
+.prfx-class>.prfx-otherclass {
+    color: white;
+}
+
+*[class^="prfx-col-"] {
+    color: white;
+}
+
+*[class^="prfx-col-"] *[class^="prfx-col-"] *[class^="prfx-col2-"] {
+    color: white;
+}


### PR DESCRIPTION
The prefixer is much more powerful now.
He can prefix complex selectors now too

e.g. tagSelector .classSelector
even an attribute selector with ^
[class^="col-"] -> can be prefixed to
[class^="prfx-col-"]
